### PR TITLE
Add support for GLPI cron

### DIFF
--- a/charts/itsm-ng/templates/deployment.yaml
+++ b/charts/itsm-ng/templates/deployment.yaml
@@ -38,7 +38,8 @@ spec:
             - >
               set -e -o pipefail ;
               echo '* * * * * cd /var/www/html/front/ && /usr/local/bin/php cron.php &>/dev/null' > /var/spool/cron/crontabs/www-data ;
-              cron 
+              cron ;
+              /init.sh
           ports:
             - name: http
               containerPort: 80

--- a/charts/itsm-ng/templates/deployment.yaml
+++ b/charts/itsm-ng/templates/deployment.yaml
@@ -32,6 +32,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: 
+            - /bin/sh
+            - -c
+            - >
+              set -e -o pipefail ;
+              echo '* * * * * cd /var/www/html/front/ && /usr/local/bin/php cron.php &>/dev/null' > /var/spool/cron/crontabs/www-data ;
+              cron 
           ports:
             - name: http
               containerPort: 80

--- a/charts/itsm-ng/templates/deployment.yaml
+++ b/charts/itsm-ng/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               set -e -o pipefail ;
               echo '* * * * * cd /var/www/html/front/ && /usr/local/bin/php cron.php &>/dev/null' > /var/spool/cron/crontabs/www-data ;
               cron ;
-              /init.sh
+              exec /init.sh
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
# ITSM-NG 


## Add support for GLPI cron with the following init command

```
command: 
  - /bin/sh
  - -c
  - >
    set -e -o pipefail ;
    echo '* * * * * cd /var/www/html/front/ && /usr/local/bin/php cron.php &>/dev/null' > /var/spool/cron/crontabs/www-data ;
    cron ;
    /init.sh
